### PR TITLE
Use Travis CI to run automated tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,26 @@
+group: travis_latest
+language: python
+cache: pip
+matrix:
+  allow_failures:
+    - python: 2.7
+  include:
+    - python: 2.7
+    #- python: 3.5
+    #- python: 3.6
+    - python: 3.7
+      dist: xenial    # required for Python >= 3.7 (travis-ci/travis-ci#9069)
+install:
+  # - pip install -r requirements.txt
+  - pip install black flake8
+before_script:
+  # stop the build if there are Python syntax errors or undefined names
+  - flake8 . --count --select=E9,F63,F72,F82 --show-source --statistics
+  # exit-zero treats all errors as warnings.  The GitHub editor is 127 chars wide
+  - flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+  - black --check || true  # ignore the errors for now
+script:
+  - true  # add other tests here
+notifications:
+  on_success: change
+  on_failure: change  # `always` will be the setting once code changes slow down


### PR DESCRIPTION
Based on your comments on achael/eht-imaging, let's try to get automated testing working on one of your repos...

To enable free automated testing of all code changes, you would need to:
1. go to https://travis-ci.com/joseangel-sc
2. log in with GitHub credentials
3. select the __free plan__, and
4. flip the repository switch __on__.

When that is done, Travis CI will lint your Python code with http://flake8.pycqa.org and https://github.com/python/black.